### PR TITLE
Return Correct API Region

### DIFF
--- a/src/main/java/com/github/theholywaffle/lolchatapi/ChatServer.java
+++ b/src/main/java/com/github/theholywaffle/lolchatapi/ChatServer.java
@@ -120,6 +120,14 @@ public enum ChatServer {
 		this.loginMethod = loginMethod;
 	}
 
+	public String getApiRegion()
+	{
+		if (api == null)
+			throw new NullPointerException("Riot API is not supported for this region.");
+
+		return api.split("\\.")[0].toLowerCase();
+	}
+
 	@Override
 	public String toString() {
 		return name().toLowerCase();

--- a/src/main/java/com/github/theholywaffle/lolchatapi/riotapi/RiotApi.java
+++ b/src/main/java/com/github/theholywaffle/lolchatapi/riotapi/RiotApi.java
@@ -109,12 +109,6 @@ public class RiotApi {
 				.openConnection();
 		connection.setRequestMethod("GET");
 		connection.setInstanceFollowRedirects(false);
-//		connection.setRequestProperty("User-Agent", "Test User Agent");
-//		connection.setRequestProperty("Accept-Language", "en-US");
-//		connection.setRequestProperty("Accept-Charset", "ISO-8859-1,utf-8");
-
-		System.out.println(requestURL);
-//		System.out.println(connection.getRequestProperties());
 
 		if (connection.getResponseCode() != 200) {
 			throw new IOException("Response code is "

--- a/src/main/java/com/github/theholywaffle/lolchatapi/riotapi/RiotApi.java
+++ b/src/main/java/com/github/theholywaffle/lolchatapi/riotapi/RiotApi.java
@@ -76,7 +76,7 @@ public class RiotApi {
 		final String summonerId = StringUtils.parseName(userId).replace("sum",
 				"");
 		final String response = request("https://" + server.api + "/api/lol/"
-				+ server + "/v1.4/summoner/" + summonerId + "/name?api_key="
+				+ server.getApiRegion() + "/v1.4/summoner/" + summonerId + "/name?api_key="
 				+ riotApiKey.getKey());
 		final Map<String, String> summoner = new GsonBuilder().create()
 				.fromJson(response, new TypeToken<Map<String, String>>() {
@@ -86,7 +86,7 @@ public class RiotApi {
 
 	public long getSummonerId(String name) throws IOException,
 			URISyntaxException {
-		final URI uri = new URI("https", server.api, "/api/lol/" + server
+		final URI uri = new URI("https", server.api, "/api/lol/" + server.getApiRegion()
 				+ "/v1.4/summoner/by-name/" + name, "api_key="
 				+ riotApiKey.getKey(), null);
 		final String response = request(uri.toASCIIString());
@@ -109,6 +109,12 @@ public class RiotApi {
 				.openConnection();
 		connection.setRequestMethod("GET");
 		connection.setInstanceFollowRedirects(false);
+//		connection.setRequestProperty("User-Agent", "Test User Agent");
+//		connection.setRequestProperty("Accept-Language", "en-US");
+//		connection.setRequestProperty("Accept-Charset", "ISO-8859-1,utf-8");
+
+		System.out.println(requestURL);
+//		System.out.println(connection.getRequestProperties());
 
 		if (connection.getResponseCode() != 200) {
 			throw new IOException("Response code is "


### PR DESCRIPTION
Added a method to return the correct API region for riot's web API. Simple fix for issues using NA2 for the api.