### PR TITLE
minimizing space used by friendListener

### DIFF
--- a/src/main/java/com/github/theholywaffle/lolchatapi/LeagueRosterListener.java
+++ b/src/main/java/com/github/theholywaffle/lolchatapi/LeagueRosterListener.java
@@ -133,7 +133,11 @@ public class LeagueRosterListener implements RosterListener {
 						l.onFriendJoin(friend);
 					} else if (p.getType() == Presence.Type.unavailable
 							&& (previousType == null || previousType != Presence.Type.unavailable)) {
+					    statusUsers.remove(friend);
+					    typeUsers.remove(friend);
+					    modeUsers.remove(friend);
 						l.onFriendLeave(friend);
+						return;
 					}
 
 					final Presence.Mode previousMode = modeUsers.get(from);


### PR DESCRIPTION
I know it's in bad style to return early, but in this situation it saves
a bunch of time. the friend left -- there is no need to update his
information in the map, and furthermore there is no need to keep his
information as it will be overwritten upon his next login. HashMap.remove() requires no checks as it simply returns null if the friend is not found. 